### PR TITLE
feat(signin_facebook): sign up/in with facebook

### DIFF
--- a/resources/client/signin_facebook.py
+++ b/resources/client/signin_facebook.py
@@ -1,0 +1,58 @@
+from flask import url_for, g
+from flask_restful import Resource
+from flask_jwt_extended import create_refresh_token, create_access_token
+
+from o_auth import facebook
+from libs.strings import gettext
+from models.client.client import ClientModel
+from models.client.confirmation import ConfirmationModel
+
+
+class FacebookSignIn(Resource):
+    @classmethod
+    def get(cls):
+        return facebook.authorize(callback=url_for('facebook.auth', _external=True))
+
+
+class FacebookAuth(Resource):
+    @classmethod
+    def get(cls):
+        response = facebook.authorized_response()
+        if response is None or response.get('access_token') is None:
+            error_message = {
+                'msg': gettext('facebook_redirect_url_error')
+            }
+            return error_message
+
+        g.access_token = response['access_token']
+
+        facebook_user = facebook.get('/me?fields=email,first_name,last_name,picture,short_name').data
+        facebook_user_email = facebook_user['email']
+
+        if not facebook_user_email:
+            return {'msg': gettext('facebook_authorization_rejected')}
+
+        client = ClientModel.find_client_by_email(facebook_user_email)
+        if not client:
+            try:
+                client = ClientModel(
+                    email=facebook_user_email,
+                    first_name=facebook_user['first_name'],
+                    last_name=facebook_user['last_name'],
+                    username=facebook_user['short_name'],
+                    oauth_token=g.access_token,
+                    password=None
+                )
+                client.save_client_to_db()
+                confirmation = ConfirmationModel(client.id)
+                confirmation.confirmed = True
+                confirmation.save_to_db()
+            except Exception as e:
+                client.delete_client_from_db()
+
+                return {'msg': str(e)}, 400
+
+        access_token = create_access_token(identity=client.email, fresh=True)
+        refresh_token = create_refresh_token(identity=client.email)
+
+        return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/tests/system/resources/test_signin_facebook.py
+++ b/tests/system/resources/test_signin_facebook.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from tests.base_test import BaseTest
+from tests.test_data import facebook_user_data
+from resources.client.signin_facebook import facebook
+
+
+class FacebookSignInTest(BaseTest):
+    @patch.object(facebook, 'authorize')
+    def test_facebook_redirect(self, mock_authorize):
+        with self.app() as test_client:
+            with self.app_context():
+                mock_authorize.return_value = 'Redirect to Facebook'
+                response = test_client.get('/client/signin/facebook')
+                mock_authorize.assert_called_once()
+                self.assertEqual(response.status_code, 200)
+
+    @patch.object(facebook, 'get')
+    @patch.object(facebook, 'authorized_response')
+    def test_facebook_callback_successful(self, mock_authorized_response, mock_get):
+        with self.app() as test_client:
+            with self.app_context():
+                mock_authorized_response.return_value = {
+                    'access_token': 'access_token'
+                }
+                mock_get.return_value.data = facebook_user_data.copy()
+                response = test_client.get('/client/facebook/auth')
+
+                mock_authorized_response.assert_called_once()
+                mock_get.assert_called_once()
+
+                self.assertIn('access_token', response.json)
+                self.assertIn('refresh_token', response.json)


### PR DESCRIPTION
### What does this PR do?
- allow client users signup/signin to PrinterConnect with their existing and verified facebook accounts
#### Description of Task to be completed?
- `GET '/client/signin/facebook'`
#### How should this be manually tested?
- With postman, send a GET request to `'/client/signin/facebook'`