### PR TITLE
feat(signin_google): sign up/in with google

### DIFF
--- a/resources/client/signin_google.py
+++ b/resources/client/signin_google.py
@@ -1,0 +1,61 @@
+from flask_restful import Resource
+from flask import url_for, g
+from flask_jwt_extended import create_access_token, create_refresh_token
+
+from models.client.client import ClientModel
+from models.client.confirmation import ConfirmationModel
+from o_auth import google
+from libs.strings import gettext
+
+
+class GoogleSignIn(Resource):
+    @classmethod
+    def get(cls):
+        return google.authorize(callback=url_for('google.auth', _external=True))
+
+
+class GoogleAuth(Resource):
+    @classmethod
+    def get(cls):
+        response = google.authorized_response()
+        if response is None or response.get('access_token') is None:
+            error_message = {
+                'msg': gettext('google_redirect_url_error')
+            }
+            return error_message
+
+        g.access_token = response['access_token']
+
+        google_user = google.get('userinfo')
+        # return google_user.data
+
+        user_email = google_user.data['email']
+
+        if not user_email:
+            return {'msg': gettext('google_verification_failed')}
+
+        client = ClientModel.find_client_by_email(user_email)
+
+        if not client:
+            try:
+                client = ClientModel(
+                    email=user_email,
+                    oauth_token=g.access_token,
+                    first_name=google_user.data['given_name'],
+                    last_name=google_user.data['family_name'],
+                    username=google_user.data['given_name']
+                )
+                client.save_client_to_db()
+
+                confirmation = ConfirmationModel(client.id)
+                confirmation.confirmed = True
+                confirmation.save_to_db()
+
+            except Exception as e:
+                client.delete_client_from_db()
+                return {'msg': str(e)}, 400
+
+        access_token = create_access_token(identity=client.email, fresh=True)
+        refresh_token = create_refresh_token(identity=client.email)
+
+        return {'access_token': access_token, 'refresh_token': refresh_token}, 200

--- a/tests/system/resources/test_signin_google.py
+++ b/tests/system/resources/test_signin_google.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from tests.base_test import BaseTest
+from tests.test_data import google_user_data
+from o_auth import google
+
+
+class GoogleSignInTest(BaseTest):
+    @patch.object(google, 'authorize')
+    def test_google_redirect(self, mock_authorize):
+        with self.app() as test_client:
+            with self.app_context():
+                mock_authorize.return_value = 'Redirect to Google'
+                response = test_client.get('/client/signin/google')
+                mock_authorize.assert_called_once()
+                self.assertEqual(response.status_code, 200)
+
+    @patch.object(google, 'get')
+    @patch.object(google, 'authorized_response')
+    def test_google_callback_successful(self, mock_authorized_response, mock_get):
+        with self.app() as test_client:
+            with self.app_context():
+                mock_authorized_response.return_value = {'access_token': 'access_token'}
+                mock_get.return_value.data = google_user_data.copy()
+                response = test_client.get('/client/google/auth')
+
+                mock_authorized_response.assert_called_once()
+                mock_get.assert_called_once()
+
+                self.assertIn('access_token', response.json)
+                self.assertIn('refresh_token', response.json)


### PR DESCRIPTION
### What does this PR do?
- allow client users to sign up/in to PrinterConnect with their verified Google accounts

#### Description of Task to be completed?
- `GET '/client/signin/google'`
#### How should this be manually tested?
- With postman, send a GET request to `/client/signin/google`