### PR TITLE
sign up/in with twitter

### DIFF
--- a/resources/client/signin_twitter.py
+++ b/resources/client/signin_twitter.py
@@ -1,0 +1,70 @@
+from flask_restful import Resource
+from flask import url_for, g
+from flask_jwt_extended import create_refresh_token, create_access_token
+
+from o_auth import twitter
+from libs.strings import split_name, gettext
+from models.client.client import ClientModel
+from models.client.confirmation import ConfirmationModel
+
+
+class TwitterSignIn(Resource):
+    @classmethod
+    def get(cls):
+        response = twitter.authorize(callback=url_for('twitter.auth', _external=True))
+        return response
+
+
+class TwitterAuth(Resource):
+    @classmethod
+    def get(cls):
+        response = twitter.authorized_response()
+        if response is None or response.get('oauth_token') is None:
+            error_response = {
+                'msg': gettext('twitter_authorized_response_error')
+            }
+
+            return error_response
+
+        g.oauth_token = response['oauth_token']
+        g.oauth_token_secret = response['oauth_token_secret']
+        g.access_token = (g.oauth_token, g.oauth_token_secret,)
+
+        verified_user = twitter.get(
+            'account/verify_credentials.json',
+            data={'include_email': 'true'}
+        )
+
+        if not verified_user.data['email']:
+            return {'msg': gettext('twitter_authorization_rejected')}, 401
+
+        if verified_user.status == 200:
+            verified_client = {
+                'email': verified_user.data['email'],
+                'username': verified_user.data['screen_name'],
+                'first_name': split_name(verified_user.data['name'])[0],
+                'last_name': split_name(verified_user.data['name'])[1],
+                'oauth_token': g.oauth_token,
+                'oauth_token_secret': g.oauth_token_secret,
+                'password': None
+            }
+
+            pc_client = ClientModel.find_client_by_email(verified_client['email'])
+
+            if not pc_client:
+                # Create new client and grant access to protected endpoints
+                try:
+                    pc_client = ClientModel(**verified_client)
+                    pc_client.save_client_to_db()
+
+                    confirmation = ConfirmationModel(pc_client.id)
+                    confirmation.confirmed = True
+                    confirmation.save_to_db()
+                except Exception as e:
+                    pc_client.delete_client_from_db()
+                    return {'msg': str(e)}, 400
+
+            access_token = create_access_token(identity=pc_client.email, fresh=True)
+            refresh_token = create_refresh_token(identity=pc_client.email)
+
+            return {"access_token": access_token, "refresh_token": refresh_token}, 200

--- a/tests/system/resources/test_signin_twitter.py
+++ b/tests/system/resources/test_signin_twitter.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+from tests.base_test import BaseTest
+from resources.client.signin_twitter import twitter
+from tests.test_data import twitter_user_data
+
+
+class TwitterSignInTest(BaseTest):
+    def test_twitter_redirect(self):
+        with self.app() as test_client:
+            with self.app_context():
+                with patch.object(twitter, 'authorize', return_value='Redirect to Twitter') as mock_twitter_authorize:
+                    url = '/client/signin/twitter'
+                    response = test_client.get(url)
+                    mock_twitter_authorize.assert_called_once()
+                    self.assertEqual(response.status_code, 200)
+
+    @patch.object(twitter, 'get')
+    @patch.object(twitter, 'authorized_response')
+    def test_twitter_callback_successful(self, mock_twitter_authorized_response, mock_twitter_get):
+        with self.app() as test_client:
+            with self.app_context():
+                mock_twitter_authorized_response.return_value = {
+                    'oauth_token': 'oauth_token',
+                    'oauth_token_secret': 'oauth_token_secret'
+                }
+
+                mock_twitter_get.return_value.data = twitter_user_data.copy()
+                mock_twitter_get.return_value.status = 200
+
+                response = test_client.get('/client/twitter/auth')
+
+                mock_twitter_authorized_response.assert_called_once()
+                mock_twitter_get.assert_called_once()
+
+                self.assertIn('access_token', response.json)
+                self.assertIn('refresh_token', response.json)


### PR DESCRIPTION
### What does this PR do?
- allow client users to sign up/in to PrinterConnect with verified twitter accounts
#### Description of Task to be completed?
- `GET '/client/signin/twitter'`
#### How should this be manually tested?
- With postman, send a `GET` request to `/client/signin/twitter`