### PR TITLE
feat(password): set/update password

### DIFF
--- a/resources/client/set_password.py
+++ b/resources/client/set_password.py
@@ -1,0 +1,31 @@
+from flask import request
+from flask_restful import Resource
+from flask_jwt_extended import jwt_required
+
+from schema.client.client import ClientSchema
+from models.client.client import ClientModel
+from libs.strings import gettext
+
+client_schema = ClientSchema()
+
+
+class SetPassword(Resource):
+    """
+    Allows signed in users to set a new password for their accounts. It takes a
+    POST request data with user email and new password
+    """
+    @classmethod
+    @jwt_required(fresh=True)
+    def post(cls):
+        client_json = request.get_json()  # email and new password
+        client_data = client_schema.load(client_json)
+
+        client = ClientModel.find_client_by_email(client_data['email'])
+
+        if not client:
+            return {'msg': gettext('set_password_client_not_found')}, 401
+
+        client.hash_password(client_data['password'])
+        client.save_client_to_db()
+
+        return {'msg': gettext('set_password_updated_successfully')}, 201

--- a/tests/system/resources/test_set_password.py
+++ b/tests/system/resources/test_set_password.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+from flask_jwt_extended.exceptions import NoAuthorizationError
+
+from tests.base_test import BaseTest
+from models.client.client import ClientModel
+from models.client.confirmation import ConfirmationModel
+from tests.test_data import client
+
+
+class SetPasswordTest(BaseTest):
+
+    def test_missing_auth_jwt(self):
+        with self.app() as test_client:
+            with self.app_context():
+                # with patch('resources.client.set_password.SetPassword.post') as mock_post:
+                test_client.post = Mock()
+                test_client.post.side_effect = NoAuthorizationError
+                signin_request_data = {'email': 'janedoe@email.com', 'password': 'pyotorovich'}
+                with self.assertRaises(NoAuthorizationError, msg='Missing Authorization Header'):
+                    test_client.post('/client/password',
+                                     json=signin_request_data,
+                                     headers={'Content-Type': 'application/json'}
+                                     )
+
+    def test_auth_jwt_available(self):
+        with self.app() as test_client:
+            with self.app_context():
+
+                new_client = ClientModel(**client.copy())
+                new_client.hash_password()
+                new_client.save_client_to_db()
+
+                confirmation = ConfirmationModel(new_client.id)
+                confirmation.confirmed = True
+                confirmation.save_to_db()
+
+                signin_request_data = {'email': 'janedoe@email.com', 'password': '12345678'}
+                signin_response = test_client.post('/client/signin/email',
+                                                   json=signin_request_data,
+                                                   headers={'Content-Type': 'application/json'}
+                                                   )
+                authorization_token = signin_response.json['jwt']['access_token']
+                header = {'Authorization': 'Bearer {}'.format(authorization_token)}
+
+                set_password_request_data = {'email': 'janedoe@email.com', 'password': 'pyotorovich'}
+                set_password_response = test_client.post('/client/password',
+                                                         json=set_password_request_data,
+                                                         headers=header
+                                                         )
+
+                self.assertEqual(set_password_response.status_code, 201)
+                self.assertEqual(set_password_response.json, {'msg': 'Password updated successfully.'})


### PR DESCRIPTION
### What does this PR do?
- allow signed-in users (via social media signin) to set a password to combine with email for alternative traditional signin
- allow signed-in users to update existing password
#### Description of Task to be completed?
- `POST '/client/password'` 
#### How should this be manually tested?
- With postman, send a post request with post body `{"email": "janedoe@email.com", "password": "supersecretpassword"}` to `/client/password`