### PR TITLE
feat(client_sign_out): implement client sign out

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,9 +18,9 @@ from resources.homepage.home import Home
 from resources.client.set_password import SetPassword
 from resources.client.avatar import AvatarUpload, Avatar
 from resources.client.sign_out import SignOut
-from resources.client.client_profile import ClientProfile
+# from resources.client.client_profile import ClientProfile
 from resources.client.token_refresh import TokenRefresh, BlockedTokens
-from resources.client.client_search import ClientSearch
+# from resources.client.client_search import ClientSearch
 from libs.image_helper import IMAGE_SET
 from dotenv import load_dotenv
 
@@ -67,9 +67,9 @@ api.add_resource(AvatarUpload, '/client/avatar/upload')
 api.add_resource(Avatar, '/client/avatar')
 api.add_resource(SignOut, '/client/signout')
 api.add_resource(BlockedTokens, '/token/blocked/<string:email>')
-api.add_resource(ClientProfile, '/client/profile')
+# api.add_resource(ClientProfile, '/client/profile')
 api.add_resource(TokenRefresh, '/token/refresh')
-api.add_resource(ClientSearch, '/client/profile/search/<string:username>')
+# api.add_resource(ClientSearch, '/client/profile/search/<string:username>')
 api.add_resource(Home, '/')
 api.add_resource(SetPassword, '/client/password')
 

--- a/models/client/token_blocklist.py
+++ b/models/client/token_blocklist.py
@@ -1,0 +1,31 @@
+from data_base import db
+
+
+class TokenBlockListModel(db.Model):
+    """Model of a valid client token rendered invalid when they sign out"""
+    __tablename__ = 'blocked_tokens'
+
+    id = db.Column(db.Integer, primary_key=True)
+    jti = db.Column(db.String(50), nullable=False)
+    client_id = db.Column(db.Integer, db.ForeignKey('clients.id'), nullable=False)
+
+    client = db.relationship('ClientModel', back_populates='token_blocklist')
+
+    def __repr__(self):
+        return '<TokenBlockList: {} - {}: {}>'.format(self.id, self.client_id, self.jti)
+
+    @classmethod
+    def find_token_by_jti(cls, jti: str) -> "TokenBlockListModel":
+        return cls.query.filter_by(jti=jti).first()
+
+    @classmethod
+    def find_tokens_by_id(cls, _id: int):
+        return cls.query.filter_by(client_id=_id).all()
+
+    def save_token_to_db(self) -> None:
+        db.session.add(self)
+        db.session.commit()
+
+    def delete_from_db(self):
+        db.session.delete(self)
+        db.session.commit()

--- a/resources/client/sign_out.py
+++ b/resources/client/sign_out.py
@@ -1,0 +1,22 @@
+import traceback
+from flask_restful import Resource
+from flask_jwt_extended import jwt_required, get_jwt, get_jwt_identity
+
+from libs.strings import gettext
+from models.client.token_blocklist import TokenBlockListModel
+from models.client.client import ClientModel
+
+
+class SignOut(Resource):
+    @classmethod
+    @jwt_required()
+    def post(cls):
+        jti = get_jwt()['jti']
+        client = ClientModel.find_client_by_id(get_jwt_identity())
+        revoked_token = TokenBlockListModel(jti=jti, client_id=client.id)
+        try:
+            revoked_token.save_token_to_db()
+            return {'msg': 'Sign out successful'}, 200
+        except Exception as e:
+            traceback.print_exc(e)
+            return {'msg': gettext('sign_out_token_addition_failed')}

--- a/resources/client/token_refresh.py
+++ b/resources/client/token_refresh.py
@@ -1,0 +1,39 @@
+from flask_restful import Resource
+from flask_jwt_extended import create_access_token, get_jwt_identity, jwt_required
+
+from libs.strings import gettext
+from models.client.client import ClientModel
+from models.client.token_blocklist import TokenBlockListModel
+from schema.client.token_blocklist import TokenBlockListSchema
+
+blocked_token_schema = TokenBlockListSchema(many=True)
+
+
+class TokenRefresh(Resource):
+    """Refresh access JWT for endpoints that require a token refreshing"""
+    @classmethod
+    @jwt_required(refresh=True)
+    def post(cls):
+        identity = get_jwt_identity()
+        new_access_token = create_access_token(identity=identity, fresh=False)
+        return {'access_token': new_access_token}, 200
+
+
+class BlockedTokens(Resource):
+    @classmethod
+    def get(cls, email):
+        """
+        View all the tokens blocked by a client
+        :return: List of blocked tokens
+        """
+        client = ClientModel.find_client_by_email(email)
+        if client is None:
+            return {'msg': gettext('client_profile_client_does_not_exist')}, 400
+        blocked_tokens_jti = [
+            token
+            for token in TokenBlockListModel.find_tokens_by_id(client.id)
+        ]
+
+        if len(blocked_tokens_jti) == 0:
+            return {'msg': gettext('token_refresh_token_blocklist_empty')}, 200
+        return {'msg': blocked_token_schema.dump(blocked_tokens_jti)}, 200

--- a/schema/client/token_blocklist.py
+++ b/schema/client/token_blocklist.py
@@ -1,0 +1,8 @@
+from marsh_mallow import ma
+from models.client.token_blocklist import TokenBlockListModel
+
+
+class TokenBlockListSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = TokenBlockListModel
+        include_fk = True


### PR DESCRIPTION
### What does this PR do?
- allow signed in clients to sign out of their account
- revoke the valid tokens assigned to clients at signin
- refresh expired tokens
#### Description of Task to be completed?
- `POST /client/signout`
- `GET /token/blocked/<string:email>`
- `GET /token/refresh`
#### How should this be manually tested?
- Use postman to send requests to each endpoint with header `{"Authorization": "Bearer {JWT}"}`

