### PR TITLE
fix client avatar delete

### DIFF
--- a/resources/client/avatar.py
+++ b/resources/client/avatar.py
@@ -15,7 +15,7 @@ avatar_schema = AvatarSchema()
 client_schema = ClientSchema(only=('avatar_url',))
 
 
-class AvatarUpload(Resource):
+class Avatar(Resource):
     @classmethod
     @jwt_required(fresh=True)
     def put(cls):
@@ -62,8 +62,6 @@ class AvatarUpload(Resource):
             extension = image_helper.get_extension(data['image'])
             return {'msg': gettext('avatar_extension_illegal').format(extension)}, 400
 
-
-class Avatar(Resource):
     @classmethod
     @jwt_required()
     def get(cls):
@@ -94,6 +92,7 @@ class Avatar(Resource):
                 os.remove(avatar)
                 client.avatar_uploaded = False
                 client.avatar_filename = None
+                client.update_client_in_db()
                 return {'msg': gettext('avatar_deleted').format(filename)}, 200
             except FileNotFoundError:
                 return {'msg': gettext('avatar_not_found').format(filename)}, 404


### PR DESCRIPTION
### What does this PR do?
- update the database with changes following avatar deletion by client
#### Description of Task to be completed?
- `DELETE /client/avatar`
#### How should this be manually tested?
With postman
- Upload an avatar: `PUT /client/avatar`
- Delete avatar: `DELETE /client/avatar`
With pgAdmin 4
- Check the state of the clients.avatar_uploaded and clients.avatar_filename fields. They should correspond to `false` and `null` respectively
- Check the project's /static/images/avatars folder. Uploaded avatar should be removed